### PR TITLE
Remove storage class from pipeline yaml to use default

### DIFF
--- a/kfp-tekton/train-upload-stock-kfp.yaml
+++ b/kfp-tekton/train-upload-stock-kfp.yaml
@@ -443,7 +443,6 @@ spec:
   - name: train-upload-stock-kfp
     volumeClaimTemplate:
       spec:
-        storageClassName: gp3
         accessModes:
         - ReadWriteOnce
         resources:


### PR DESCRIPTION
This should work better if they have a default storage class created.